### PR TITLE
Fix react checksum error.

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -17,7 +17,6 @@ var subscribe = require('subscribe-ui-event').subscribe;
 var STATUS_ORIGINAL = 0; // The default status, locating at the original position.
 var STATUS_RELEASED = 1; // The released status, locating at somewhere on document but not default one.
 var STATUS_FIXED = 2; // The sticky status, locating fixed to the top or the bottom of screen.
-var TRANSFORM_PROP = 'transform';
 
 // global variable for all instances
 var doc;
@@ -41,7 +40,6 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     // No Sticky on lower-end browser when no Modernizr
     if (M) {
         enableTransforms = M.csstransforms3d;
-        TRANSFORM_PROP = M.prefixed('transform');
     }
 }
 
@@ -283,7 +281,9 @@ class Sticky extends React.Component {
 
     translate (style, pos) {
         if (enableTransforms) {
-            style[TRANSFORM_PROP] = 'translate3d(0,' + pos + 'px,0)';
+            style['transform'] = 'translate3d(0,' + pos + 'px,0)';
+            style['WebkitTransform'] = 'translate3d(0,' + pos + 'px,0)';
+            style['MsTransform'] = 'translate3d(0,' + pos + 'px,0)';
         } else {
             style.top = pos;
         }

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -17,6 +17,7 @@ var subscribe = require('subscribe-ui-event').subscribe;
 var STATUS_ORIGINAL = 0; // The default status, locating at the original position.
 var STATUS_RELEASED = 1; // The released status, locating at somewhere on document but not default one.
 var STATUS_FIXED = 2; // The sticky status, locating fixed to the top or the bottom of screen.
+var TRANSFORM_PROP = 'transform';
 
 // global variable for all instances
 var doc;
@@ -40,6 +41,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     // No Sticky on lower-end browser when no Modernizr
     if (M) {
         enableTransforms = M.csstransforms3d;
+        TRANSFORM_PROP = M.prefixed('transform');
     }
 }
 
@@ -67,7 +69,8 @@ class Sticky extends React.Component {
             topBoundary: 0, // The top boundary on document
             bottomBoundary: Infinity, // The bottom boundary on document
             status: STATUS_ORIGINAL, // The Sticky status
-            pos: 0 // Real y-axis offset for rendering position-fixed and position-relative
+            pos: 0, // Real y-axis offset for rendering position-fixed and position-relative
+            activated: false
         };
     }
 
@@ -270,6 +273,7 @@ class Sticky extends React.Component {
     componentDidMount () {
         var self = this;
         if (self.props.enabled) {
+            self.setState({activated: true});
             self.updateInitialDimension();
             self.subscribers = [
                 subscribe('scrollStart', self.handleScrollStart.bind(self), {useRAF: true}),
@@ -280,10 +284,8 @@ class Sticky extends React.Component {
     }
 
     translate (style, pos) {
-        if (enableTransforms) {
-            style['transform'] = 'translate3d(0,' + pos + 'px,0)';
-            style['WebkitTransform'] = 'translate3d(0,' + pos + 'px,0)';
-            style['MsTransform'] = 'translate3d(0,' + pos + 'px,0)';
+        if (enableTransforms && this.state.activated) {
+            style[TRANSFORM_PROP] = 'translate3d(0,' + pos + 'px,0)';
         } else {
             style.top = pos;
         }

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -70,7 +70,7 @@ class Sticky extends React.Component {
             bottomBoundary: Infinity, // The bottom boundary on document
             status: STATUS_ORIGINAL, // The Sticky status
             pos: 0, // Real y-axis offset for rendering position-fixed and position-relative
-            activated: false
+            activated: false // once browser info is available after mounted, it becomes true to avoid checksum error 
         };
     }
 

--- a/tests/unit/Sticky-test.js
+++ b/tests/unit/Sticky-test.js
@@ -104,6 +104,11 @@ function shouldBeReset (t) {
     expect(style.top).to.be('');
 }
 
+function checkTransform3d (inner) {
+    var style = inner._reactInternalComponent._currentElement.props.style;
+    expect(style.transform).to.contain('translate3d');
+}
+
 describe('Sticky', function () {
     beforeEach(function () {
         STICKY_WIDTH = 100;
@@ -127,7 +132,7 @@ describe('Sticky', function () {
         expect(outer.className).to.contain('sticky-outer-wrapper');
         expect(inner.className).to.contain('sticky-inner-wrapper');
         // should always have translate3d
-        expect(inner.getAttribute('style')).to.contain('transform:translate3d');
+        checkTransform3d(inner);
 
         // Scroll down to 10px, and Sticky should fix
         window.scrollTo(0, 10);
@@ -148,7 +153,7 @@ describe('Sticky', function () {
         expect(outer.className).to.contain('sticky-outer-wrapper');
         expect(inner.className).to.contain('sticky-inner-wrapper');
         // should always have translate3d
-        expect(inner.getAttribute('style')).to.contain('transform:translate3d');
+        checkTransform3d(inner);
 
         // Scroll down to 10px, and Sticky should stay as it was
         window.scrollTo(0, 10);
@@ -185,7 +190,7 @@ describe('Sticky', function () {
         expect(outer.className).to.contain('sticky-outer-wrapper');
         expect(inner.className).to.contain('sticky-inner-wrapper');
         // should always have translate3d
-        expect(inner.getAttribute('style')).to.contain('transform:translate3d');
+        checkTransform3d(inner);
 
         // Scroll down to 10px, and Sticky should stay
         window.scrollTo(0, 10);
@@ -208,7 +213,7 @@ describe('Sticky', function () {
         expect(outer.className).to.contain('sticky-outer-wrapper');
         expect(inner.className).to.contain('sticky-inner-wrapper');
         // should always have translate3d
-        expect(inner.getAttribute('style')).to.contain('transform:translate3d');
+        checkTransform3d(inner);
 
         // Scroll down to 10px, and Sticky should stay
         window.scrollTo(0, 10);
@@ -234,7 +239,7 @@ describe('Sticky', function () {
         expect(outer.className).to.contain('sticky-outer-wrapper');
         expect(inner.className).to.contain('sticky-inner-wrapper');
         // should always have translate3d
-        expect(inner.getAttribute('style')).to.contain('transform:translate3d');
+        checkTransform3d(inner);
 
         // Scroll down to 10px, and Sticky should stay
         window.scrollTo(0, 10);
@@ -258,7 +263,7 @@ describe('Sticky', function () {
         expect(outer.className).to.contain('sticky-outer-wrapper');
         expect(inner.className).to.contain('sticky-inner-wrapper');
         // should always have translate3d
-        expect(inner.getAttribute('style')).to.contain('transform:translate3d');
+        checkTransform3d(inner);
 
         // Scroll down to 10px, and Sticky should fix
         window.scrollTo(0, 10);
@@ -283,7 +288,7 @@ describe('Sticky', function () {
         expect(outer.className).to.contain('sticky-outer-wrapper');
         expect(inner.className).to.contain('sticky-inner-wrapper');
         // should always have translate3d
-        expect(inner.getAttribute('style')).to.contain('transform:translate3d');
+        checkTransform3d(inner);
 
         // Scroll down to 10px, and Sticky should fix
         window.scrollTo(0, 10);


### PR DESCRIPTION
On server side transform_prop is always transform but on client side on IE and Safari, it's different so we have checksum error.

This fix makes it so that no matter what we show the same transform but depending on the browser the right one will start working.  We'll have little more chars on the mark up but that's not a deal-breaker performance change.

@hankhsiao @src-code 