### PR TITLE
Use getBoundingClientRect().width for better precision

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -150,7 +150,7 @@ class Sticky extends React.Component {
         var inner = self.refs.inner;
         var outerRect = outer.getBoundingClientRect();
 
-        var width = outer.offsetWidth;
+        var width = outerRect.width;
         var height = inner.offsetHeight;
         var outerY = outerRect.top + scrollTop;
 


### PR DESCRIPTION
Tested with chrome on MBP retina:
element.offsetWidth is rounded and can have 1px of difference with the actual displayed size.
This lead to cases where the sticked width differ from the original width.
Using  getBoundingClientRect().width fixed the issue.