### PR TITLE
Remove overflow hidden that prevents expandable contents.

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -70,7 +70,7 @@ class Sticky extends React.Component {
             bottomBoundary: Infinity, // The bottom boundary on document
             status: STATUS_ORIGINAL, // The Sticky status
             pos: 0, // Real y-axis offset for rendering position-fixed and position-relative
-            activated: false // once browser info is available after mounted, it becomes true to avoid checksum error 
+            activated: false // once browser info is available after mounted, it becomes true to avoid checksum error
         };
     }
 
@@ -299,7 +299,6 @@ class Sticky extends React.Component {
         var self = this;
         // TODO, "overflow: auto" prevents collapse, need a good way to get children height
         var style = {
-            overflow: 'hidden',
             position: self.state.status === STATUS_FIXED ? 'fixed' : 'relative',
             top: self.state.status === STATUS_FIXED ? '0' : ''
         };


### PR DESCRIPTION
For example, an expandable ad creative, is prevented from being hosted in a StickyNode enabled region.