### PR TITLE
Allow disabling CSS transforms via props

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ var Sticky = require('react-stickynode');
 - `enabled {Boolean}` - The switch to enable or disable Sticky (true by default).
 - `top {Number/String}` - The offset from the top of window where the top of the element will be when sticky state is triggered (0 by default). If it is a selector to a target (via `querySelector()`), the offset will be the height of the target.
 - `bottomBoundary {Number/String}` - The offset from the top of document which release state will be triggered when the bottom of the element reaches at. If it is a selector to a target (via `querySelector()`), the offset will be the bottom of the target.
+- `enableTransforms {Boolean}` - Enable the use of CSS3 transforms (true by default)
 
 ## Install & Development
 

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -23,7 +23,7 @@ var TRANSFORM_PROP = 'transform';
 var doc;
 var docBody;
 var docEl;
-var enableTransforms = true; // Use transform by default, so no Sticky on lower-end browser when no Modernizr
+var canEnableTransforms = true; // Use transform by default, so no Sticky on lower-end browser when no Modernizr
 var M;
 var scrollDelta = 0;
 var scrollTop = -1;
@@ -40,7 +40,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     M = window.Modernizr;
     // No Sticky on lower-end browser when no Modernizr
     if (M) {
-        enableTransforms = M.csstransforms3d;
+        canEnableTransforms = M.csstransforms3d;
         TRANSFORM_PROP = M.prefixed('transform');
     }
 }
@@ -284,6 +284,7 @@ class Sticky extends React.Component {
     }
 
     translate (style, pos) {
+        var enableTransforms = canEnableTransforms && this.props.enableTransforms
         if (enableTransforms && this.state.activated) {
             style[TRANSFORM_PROP] = 'translate3d(0,' + pos + 'px,0)';
         } else {
@@ -322,7 +323,8 @@ class Sticky extends React.Component {
 Sticky.defaultProps = {
     enabled: true,
     top: 0,
-    bottomBoundary: 0
+    bottomBoundary: 0,
+    enableTransforms: true
 };
 
 /**
@@ -342,7 +344,8 @@ Sticky.propTypes = {
         propTypes.object,  // TODO, may remove
         propTypes.string,
         propTypes.number
-    ])
+    ]),
+    enableTransforms: propTypes.bool
 };
 
 module.exports = Sticky;


### PR DESCRIPTION
I was having bad results using this module with the CSS transforms: my sidebar (longer than the window height) kept flickering on state transitions (original > fixed, fixed > released).

That problem disappeared when I switched off the use of CSS transforms, so this is a PR to allow doing it from the props, even if the browser supports them (the default is still to enable them).