### PR TITLE
fix incorrect calculation of height

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -220,8 +220,8 @@ class Sticky extends React.Component {
             self.stickyTop = self.stickyBottom - self.state.height;
             self.release(self.stickyTop);
         } else {
-            if (self.state.height > winHeight) {
-                // In this case, Sticky is larger then screen
+            if (self.state.height > winHeight - self.state.top) {
+                // In this case, Sticky is larger then screen minus sticky top
                 switch (self.state.status) {
                     case STATUS_ORIGINAL:
                         self.release(self.state.y);


### PR DESCRIPTION
@roderickhsiao the case that sticky is higher then screen should consider sticky top as well.

@codeheroics I think it is the root cause of your jumping issue https://github.com/yahoo/react-stickynode/pull/14. As you can see in the code, there are a lot of hard decision not to make sticky out of boundaries. The bug you found is like some incorrect calculation. Can you help me try your case again after merging this PR.