### PR TITLE
Upgrade to React 15 and remove shallow compare dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,6 @@ module.exports = function (grunt) {
                 module: {
                     loaders: [
                         { test: /\.css$/, loader: 'style!css' },
-                        { test: /\.jsx$/, loader: 'jsx-loader' },
                         { test: /\.json$/, loader: 'json-loader'}
                     ]
                 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "classnames": "^2.0.0",
-    "react-addons-shallow-compare": "^0.14.2",
+    "is-equal-shallow": "^0.1.0",
     "subscribe-ui-event": "^1.0.0"
   },
   "devDependencies": {
@@ -53,20 +53,19 @@
     "grunt-webpack": "^1.0.8",
     "istanbul": "^0.4.0",
     "jsdom": "^8.0.0",
-    "jsx-loader": "^0.13.2",
-    "jsx-test": "^0.8.0",
+    "jsx-test": "^1.0.0",
     "minimist": "^1.2.0",
     "mocha": "^2.0",
     "mockery": "^1.4.0",
     "pre-commit": "^1.0.0",
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2",
+    "react": "^0.14.2 || ^15.0.0",
+    "react-dom": "^0.14.2 || ^15.0.0",
     "sinon": "^1.17.3",
     "xunit-file": "~0.0.9"
   },
   "peerDependencies": {
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "react": "^0.14.2 || ^15.0.0",
+    "react-dom": "^0.14.2 || ^15.0.0"
   },
   "precommit": [
     "lint",

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -6,11 +6,11 @@
 
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
+import React, {Component, PropTypes} from 'react';
 
+import {subscribe} from 'subscribe-ui-event';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
-import { subscribe } from 'subscribe-ui-event';
+import isEqual from 'is-equal-shallow';
 
 // constants
 const STATUS_ORIGINAL = 0; // The default status, locating at the original position.
@@ -145,8 +145,8 @@ class Sticky extends Component {
     updateInitialDimension () {
         var self = this;
 
-        var outer = self.refs.outer;
-        var inner = self.refs.inner;
+        var {outer, inner} = self.refs;
+
         var outerRect = outer.getBoundingClientRect();
         var innerRect = inner.getBoundingClientRect();
 
@@ -317,7 +317,7 @@ class Sticky extends Component {
     }
 
     shouldComponentUpdate (nextProps, nextState) {
-        return shallowCompare(this, nextProps, nextState);
+        return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState);
     }
 
     render () {

--- a/tests/unit/Sticky-test.js
+++ b/tests/unit/Sticky-test.js
@@ -83,30 +83,30 @@ window.resizeTo = function (x, y) {
 };
 
 function shouldBeFixedAt (t, pos) {
-    var style = t._reactInternalComponent._currentElement.props.style;
-    expect(style.width).to.be(100);
+    var style = t._style;
+    expect(style.width).to.be('100px');
     expect(style.transform).to.be('translate3d(0,' + pos + 'px,0)');
     expect(style.position).to.be('fixed');
-    expect(style.top).to.be('0');
+    expect(style.top).to.be('0px');
 }
 
 function shouldBeReleasedAt (t, pos) {
-    var style = t._reactInternalComponent._currentElement.props.style;
-    expect(style.width).to.be(100);
+    var style = t._style;
+    expect(style.width).to.be('100px');
     expect(style.transform).to.be('translate3d(0,' + pos + 'px,0)');
     expect(style.position).to.be('relative');
     expect(style.top).to.be('');
 }
 
 function shouldBeReset (t) {
-    var style = t._reactInternalComponent._currentElement.props.style;
+    var style = t._style;
     expect(style.transform).to.be('translate3d(0,0px,0)');
     expect(style.position).to.be('relative');
     expect(style.top).to.be('');
 }
 
 function checkTransform3d (inner) {
-    var style = inner._reactInternalComponent._currentElement.props.style;
+    var style = inner._style;
     expect(style.transform).to.contain('translate3d');
 }
 


### PR DESCRIPTION
@hankhsiao 

now react will throw warning on unitless value, we will probably need to change it as well.