### PR TITLE
Toggling sticky behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "mockery": "^1.4.0",
     "pre-commit": "^1.0.0",
     "react": "^0.14.2 || ^15.0.0",
+    "react-addons-test-utils": "^0.14.2 || ^15.0.0",
     "react-dom": "^0.14.2 || ^15.0.0",
     "sinon": "^1.17.3",
     "xunit-file": "~0.0.9"

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -278,8 +278,22 @@ class Sticky extends Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (prevState.status !== this.state.status && this.props.onStateChange) {
-            this.props.onStateChange({status: this.state.status});
+        var self = this;
+        if (prevState.status !== self.state.status && self.props.onStateChange) {
+            self.props.onStateChange({status: self.state.status});
+        }
+        // if the props for enabling are toggled, then trigger the update or reset depending on the current props
+        if (prevProps.enabled !== self.props.enabled) {
+            if (self.props.enabled) {
+                this.setState({activated: true}, function(){
+                    self.updateInitialDimension();
+                    self.update();
+                });
+            } else {
+                this.setState({activated: false}, function(){
+                    self.reset();
+                });
+            }
         }
     }
 
@@ -299,12 +313,13 @@ class Sticky extends Component {
             self.setState({activated: true});
             self.updateInitialDimension();
             this.update();
-            self.subscribers = [
-                subscribe('scrollStart', self.handleScrollStart.bind(self), {useRAF: true}),
-                subscribe('scroll', self.handleScroll.bind(self), {useRAF: true, enableScrollInfo: true}),
-                subscribe('resize', self.handleResize.bind(self), {enableResizeInfo: true})
-            ];
         }
+        // bind the listeners regardless if initially enabled - allows the component to toggle sticky functionality
+        self.subscribers = [
+            subscribe('scrollStart', self.handleScrollStart.bind(self), {useRAF: true}),
+            subscribe('scroll', self.handleScroll.bind(self), {useRAF: true, enableScrollInfo: true}),
+            subscribe('resize', self.handleResize.bind(self), {enableResizeInfo: true})
+        ];
     }
 
     translate (style, pos) {

--- a/tests/unit/Sticky-test.js
+++ b/tests/unit/Sticky-test.js
@@ -380,4 +380,29 @@ describe('Sticky', function () {
         shouldBeFixedAt(inner, -532);
         expect(outer.className).to.contain('active');
     });
+
+    it('should allow the sticky functionality to be toggled off', function () {
+        var ReactTestUtils = require('react-addons-test-utils');
+        var React = require('react');
+        // setup a wrapper to simulate the controlling of the sticky prop
+        var ParentComponent = React.createFactory(React.createClass({
+            getInitialState() {
+                return { enabled: true };
+            },
+            render() {
+                return <Sticky ref="sticky" enabled={this.state.enabled} />
+            }
+        }));
+
+        var parent = ReactTestUtils.renderIntoDocument(ParentComponent());
+        // toggle the enabled prop off
+        parent.setState({enabled: false});
+        // assert that the toggle of the props and state
+        expect(parent.refs.sticky.props.enabled).to.eql(false);
+        expect(parent.refs.sticky.state.activated).to.eql(false);
+        // toggle the enabled prop on
+        parent.setState({enabled: true});
+        expect(parent.refs.sticky.props.enabled).to.eql(true);
+        expect(parent.refs.sticky.state.activated).to.eql(true);
+    });
 });


### PR DESCRIPTION
This change allows the sticky behavior to be toggled on and off via the enabled property. We had a use case where a toolbar was desired to be sticky only if a batching function was enabled for a list of items. Setting the enabled prop to true initially would allow the sticky to be toggle; however, without being able to call update or reset, lead to a broken feeling experience.