### PR TITLE
fixed Sticky not being fixed when calling window.scrollTo()

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -222,7 +222,9 @@ class Sticky extends Component {
                         self.release(self.state.y);
                         self.stickyTop = self.state.y;
                         self.stickyBottom = self.stickyTop + self.state.height;
-                        break;
+                        // Commentting out "break" is on purpose, because there is a chance to transit to FIXED
+                        // from ORIGINAL when calling window.scrollTo().
+                        // break;
                     case STATUS_RELEASED:
                         // If "top" and "bottom" are inbetween stickyTop and stickyBottom, then Sticky is in
                         // RELEASE status. Otherwise, it changes to FIXED status, and its bottom sticks to


### PR DESCRIPTION
@hankhsiao  

fix the issue if users call window.scrollTo directly, 
we will just go to `release` mode and will need to wait for next render to toggle to `fixed` mode 

will have setState twice, but should be ok since it's edge case, 
then we are still going to the flow, `original -> release -> fixed`