### PR TITLE
Explicitly add displayName for better debugging

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -366,6 +366,8 @@ class Sticky extends Component {
     }
 }
 
+Sticky.displayName = 'Sticky';
+
 Sticky.defaultProps = {
     enabled: true,
     top: 0,


### PR DESCRIPTION
Currently, the `Sticky` ES6 component does not set the displayName explicitly, so its not helpful in the react plugin tab. Adding it to aid debugging.

@kaesonho 
![no displayName for Sticky](http://i.imgur.com/MyJ3PWy.png)