### PR TITLE
Adding support for shouldFreeze hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ var Sticky = require('react-stickynode');
 - `enableTransforms {Boolean}` - Enable the use of CSS3 transforms (true by default).
 - `activeClass {String}` - Class name to be applied to the element when the sticky state is active (`active` by default).
 - `onStateChange {Function}` - Callback for when the sticky state changes. See below.
+- `shouldFreeze {Function}` - Callback to indicate when the sticky plugin should freeze position and ignore scroll/resize events. See below.
 
 ### Handling State Change
 
@@ -77,6 +78,10 @@ const handleStateChange = (status) => {
     <YourComponent/>
 </Sticky>
 ```
+
+### Freezing 
+
+You can provide a function in the `shouldFreeze` prop which will tell the component to temporarily stop updating during prop and state changes, as well as ignore scroll and resize events. This function should return a boolean indicating whether the component should currently be frozen. 
 
 ## Install & Development
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "classnames": "^2.0.0",
-    "deep-equal": "~1.0.1",
+    "deep-equal": "^1.0.1",
     "subscribe-ui-event": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "classnames": "^2.0.0",
-    "is-equal-shallow": "^0.1.0",
+    "deep-equal": "~1.0.1",
     "subscribe-ui-event": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "classnames": "^2.0.0",
-    "deep-equal": "^1.0.1",
+    "is-equal-shallow": "^0.1.0",
     "subscribe-ui-event": "^1.0.0"
   },
   "devDependencies": {

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -54,6 +54,7 @@ class Sticky extends Component {
         this.delta = 0;
         this.stickyTop = 0;
         this.stickyBottom = 0;
+        this.frozen = false;
 
         this.bottomBoundaryTarget;
         this.topTarget;
@@ -170,7 +171,9 @@ class Sticky extends Component {
     }
 
     handleResize (e, ae) {
-        if (this.props.shouldFreeze()) { return; }
+        if (this.props.shouldFreeze()) {
+            return;
+        }
 
         winHeight = ae.resize.height;
         this.updateInitialDimension();
@@ -178,14 +181,20 @@ class Sticky extends Component {
     }
 
     handleScrollStart (e, ae) {
-        if (this.props.shouldFreeze()) { return; }
+        this.frozen = this.props.shouldFreeze();
+
+        if (this.frozen) {
+            return;
+        }
         
         scrollTop = ae.scroll.top;
         this.updateInitialDimension();
     }
 
     handleScroll (e, ae) {
-        if (this.props.shouldFreeze()) { return; }
+        if (this.frozen) { 
+            return;
+        }
 
         scrollDelta = ae.scroll.delta;
         scrollTop = ae.scroll.top;

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -10,7 +10,7 @@ import React, {Component, PropTypes} from 'react';
 
 import {subscribe} from 'subscribe-ui-event';
 import classNames from 'classnames';
-import isEqual from 'is-equal-shallow';
+import isEqual from 'deep-equal';
 
 // constants
 const STATUS_ORIGINAL = 0; // The default status, locating at the original position.
@@ -170,17 +170,23 @@ class Sticky extends Component {
     }
 
     handleResize (e, ae) {
+        if (this.props.shouldFreeze()) { return; }
+
         winHeight = ae.resize.height;
         this.updateInitialDimension();
         this.update();
     }
 
     handleScrollStart (e, ae) {
+        if (this.props.shouldFreeze()) { return; }
+        
         scrollTop = ae.scroll.top;
         this.updateInitialDimension();
     }
 
     handleScroll (e, ae) {
+        if (this.props.shouldFreeze()) { return; }
+
         scrollDelta = ae.scroll.delta;
         scrollTop = ae.scroll.top;
         this.update();
@@ -337,7 +343,7 @@ class Sticky extends Component {
     }
 
     shouldComponentUpdate (nextProps, nextState) {
-        return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState);
+        return !this.props.shouldFreeze() && (!isEqual(this.props, nextProps) || !isEqual(this.state, nextState));
     }
 
     render () {
@@ -369,6 +375,7 @@ class Sticky extends Component {
 Sticky.displayName = 'Sticky';
 
 Sticky.defaultProps = {
+    shouldFreeze: function () { return false; },
     enabled: true,
     top: 0,
     bottomBoundary: 0,
@@ -397,7 +404,8 @@ Sticky.propTypes = {
     ]),
     enableTransforms: PropTypes.bool,
     activeClass: PropTypes.string,
-    onStateChange: PropTypes.func
+    onStateChange: PropTypes.func,
+    shouldFreeze: PropTypes.func
 };
 
 Sticky.STATUS_ORIGINAL = STATUS_ORIGINAL;

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -10,7 +10,7 @@ import React, {Component, PropTypes} from 'react';
 
 import {subscribe} from 'subscribe-ui-event';
 import classNames from 'classnames';
-import isEqual from 'deep-equal';
+import isEqual from 'is-equal-shallow';
 
 // constants
 const STATUS_ORIGINAL = 0; // The default status, locating at the original position.


### PR DESCRIPTION
Adding the ability to temporarily "turn off" a sticky node.  This is intended to be different from the `enabled` prop, which resets the Sticky element - instead, this is a temporary disabling of the component so it doesn't respond to prop changes and scroll/resize events.

Also switching the package used to test for prop and state changes, because `is-equal-shallow` is not suitable for testing props, which includes an object property (`children`) and thus will always cause `isEqual()` to return `false`.  I'm open to using different methods for testing for prop changes however, or eliminating this check altogether if the perf impact isn't significant.