### PR TITLE
Ensuring accurate stickyBottom when in RELEASE mode in case of height change

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -247,6 +247,7 @@ class Sticky extends Component {
                         // If "top" and "bottom" are inbetween stickyTop and stickyBottom, then Sticky is in
                         // RELEASE status. Otherwise, it changes to FIXED status, and its bottom sticks to
                         // viewport bottom when scrolling down, or its top sticks to viewport top when scrolling up.
+                        self.stickyBottom = self.stickyTop + self.state.height;
                         if (delta > 0 && bottom > self.stickyBottom) {
                             self.fix(self.state.bottom - self.state.height);
                         } else if (delta < 0 && top < self.stickyTop) {


### PR DESCRIPTION
If a height change has occurred while in "release" mode, a bug will occur since `update()` will rely on an outdated value for `stickyBottom` when deciding whether to fix the stickynode in place.  This fix simply updates the value of `stickyBottom` before using the value for computations.

@roderickhsiao @hankhsiao @alexnj 