### PR TITLE
Don't handle scroll if scrollTop value hasn't changed

### DIFF
--- a/tests/unit/Sticky-test.js
+++ b/tests/unit/Sticky-test.js
@@ -370,12 +370,12 @@ describe('Sticky', function () {
         // Change Sticky's height
         STICKY_HEIGHT = 1300;
 
-        // Scroll up to 1550px, and Sticky should release and stay where it was
+        // Scroll down to 1550px, and Sticky should release and stay where it was
         window.scrollTo(0, 1550);
         shouldBeReleasedAt(inner, 1068);
         expect(outer.className).to.not.contain('active');
 
-        // Scroll down to 1650px, and Sticky should release as it was
+        // Scroll down to 1650px, and Sticky should become fixed again
         window.scrollTo(0, 1650);
         shouldBeFixedAt(inner, -532);
         expect(outer.className).to.contain('active');


### PR DESCRIPTION
@hankhsiao @roderickhsiao @mattho 

Another approach to avoiding the problem of scroll restoration triggering a mis-layout of the sticky node.  In this case, if the current `scrollTop` value matches the cached value during `handleScrollStart()`, we don't update the sticky node.  

Replaces PR #41