### PR TITLE
accept props.innerZ to z-index the sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ var Sticky = require('react-stickynode');
 - `enabled {Boolean}` - The switch to enable or disable Sticky (true by default).
 - `top {Number/String}` - The offset from the top of window where the top of the element will be when sticky state is triggered (0 by default). If it is a selector to a target (via `querySelector()`), the offset will be the height of the target.
 - `bottomBoundary {Number/String}` - The offset from the top of document which release state will be triggered when the bottom of the element reaches at. If it is a selector to a target (via `querySelector()`), the offset will be the bottom of the target.
+- `innerZ {Number/String}` - z-index of the sticky
 - `enableTransforms {Boolean}` - Enable the use of CSS3 transforms (true by default).
 - `activeClass {String}` - Class name to be applied to the element when the sticky state is active (`active` by default).
 - `onStateChange {Function}` - Callback for when the sticky state changes. See below.

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -369,7 +369,8 @@ class Sticky extends Component {
         // TODO, "overflow: auto" prevents collapse, need a good way to get children height
         var innerStyle = {
             position: self.state.status === STATUS_FIXED ? 'fixed' : 'relative',
-            top: self.state.status === STATUS_FIXED ? '0px' : ''
+            top: self.state.status === STATUS_FIXED ? '0px' : '',
+            zIndex: self.props.innerZ
         };
         var outerStyle = {};
 
@@ -423,7 +424,11 @@ Sticky.propTypes = {
     enableTransforms: PropTypes.bool,
     activeClass: PropTypes.string,
     onStateChange: PropTypes.func,
-    shouldFreeze: PropTypes.func
+    shouldFreeze: PropTypes.func,
+    innerZ: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ])
 };
 
 Sticky.STATUS_ORIGINAL = STATUS_ORIGINAL;


### PR DESCRIPTION
I'm running into some issues with the styles where I need to have a `z-index` defined because I want the content to scroll underneath rather than over it (videoplayers).  This allows us to pass a z for the inner element.

@src-code 