### PR TITLE
[issue #39] Switching from is-equal-shallow to React's shallowCompare addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "classnames": "^2.0.0",
-    "is-equal-shallow": "^0.1.0",
+    "react-addons-shallow-compare": "^0.14.2 || ^15.0.0",
     "subscribe-ui-event": "^1.0.0"
   },
   "devDependencies": {

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -10,7 +10,7 @@ import React, {Component, PropTypes} from 'react';
 
 import {subscribe} from 'subscribe-ui-event';
 import classNames from 'classnames';
-import isEqual from 'is-equal-shallow';
+import shallowCompare from 'react-addons-shallow-compare';
 
 // constants
 const STATUS_ORIGINAL = 0; // The default status, locating at the original position.
@@ -355,7 +355,7 @@ class Sticky extends Component {
     }
 
     shouldComponentUpdate (nextProps, nextState) {
-        return !this.props.shouldFreeze() && (!isEqual(this.props, nextProps) || !isEqual(this.state, nextState));
+        return !this.props.shouldFreeze() && shallowCompare(this, nextProps, nextState);
     }
 
     render () {


### PR DESCRIPTION
Addressing issue #39.  Making use of `shallowCompare` instead of the buggy `is-equal-shallow`

https://facebook.github.io/react/docs/shallow-compare.html

@hankhsiao @kaesonho @redonkulus