### PR TITLE
Addresses issue when passing a new top/bottomBoundary property

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -283,7 +283,21 @@ class Sticky extends Component {
         this.delta = delta;
     }
 
+    updateElements ( nextProps ) {
+        if ( !nextProps ) {
+          return;
+        }
+
+        if ( (typeof nextProps.bottomBoundary === 'string') && (nextProps.bottomBoundary !== this.props.bottomBoundary) ) {
+            this.bottomBoundaryTarget = doc.querySelector(nextProps.bottomBoundary);
+        }
+        if ( (typeof nextProps.top === 'string' ) && (nextProps.top !== this.props.top) ) {
+            this.topTarget = doc.querySelector(nextProps.top);
+        }
+    }
+
     componentWillReceiveProps (nextProps) {
+        this.updateElements(nextProps)
         this.updateInitialDimension(nextProps);
         this.update();
     }


### PR DESCRIPTION
The cached DOM element wasn’t being refreshed on componentDidReceiveProps and always assuming the first element.
This is true for both the [bottom](https://github.com/yahoo/react-stickynode/blob/master/src/Sticky.jsx#L74) and [top](https://github.com/yahoo/react-stickynode/blob/master/src/Sticky.jsx#L100) boundary elements
