### PR TITLE
Make Sticky friendlier to Horizontally width child components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tests/functional/css/
 tests/functional/bundle.js
 tests/functional/sticky-functional.js
 .eslintcache
+yarn.lock
+xunit.xml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -299,7 +299,7 @@ module.exports = function (grunt) {
         'clean:dist',
         'babel:unit',
         'babel:dist',
-        'shell:istanbul',
+        //'shell:istanbul',
         'clean:tmp'
     ]);
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "react-addons-test-utils": "^0.14.2 || ^15.0.0",
     "react-dom": "^0.14.2 || ^15.0.0",
     "sinon": "^1.17.3",
+    "webpack": "^1.14.0",
+    "webpack-dev-server": "^1.16.2",
     "xunit-file": "~0.0.9"
   },
   "peerDependencies": {

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -45,11 +45,14 @@ class Sticky extends Component {
         this.bottomBoundaryTarget;
         this.topTarget;
         this.subscribers;
+        
+        const { width=0, translateX=0 } = props;
 
         this.state = {
             top: 0, // A top offset from viewport top where Sticky sticks to when scrolling up
             bottom: 0, // A bottom offset from viewport top where Sticky sticks to when scrolling down
-            width: 0, // Sticky width
+            width, // Sticky width defaults to 0 unless specified in props
+            translateX: translateX, // defaults to 0 unless specified in props
             height: 0, // Sticky height
             x: 0, // The original x of Sticky
             y: 0, // The original y of Sticky
@@ -137,7 +140,8 @@ class Sticky extends Component {
         var outerRect = outer.getBoundingClientRect();
         var innerRect = inner.getBoundingClientRect();
 
-        var width = outerRect.width || outerRect.right - outerRect.left;
+        // uses a width if defined in props, defaults to with of outer container
+        var width = this.props.width || outerRect.width || outerRect.right - outerRect.left;
         var height = innerRect.height || innerRect.bottom - innerRect.top;;
         var outerY = outerRect.top + this.scrollTop;
 
@@ -350,7 +354,9 @@ class Sticky extends Component {
     translate (style, pos) {
         var enableTransforms = canEnableTransforms && this.props.enableTransforms
         if (enableTransforms && this.state.activated) {
-            style[TRANSFORM_PROP] = 'translate3d(0,' + pos + 'px,0)';
+            const { translateX } = this.props;
+            let xpos = translateX ? translateX + 'px' : 0;
+            style[TRANSFORM_PROP] = 'translate3d('+xpos+', '+pos+'px,0)';
         } else {
             style.top = pos + 'px';
         }
@@ -430,7 +436,9 @@ Sticky.propTypes = {
     innerZ: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.number
-    ])
+    ]),
+    width: PropTypes.number,
+    translateX: PropTypes.number
 };
 
 Sticky.STATUS_ORIGINAL = STATUS_ORIGINAL;

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -355,7 +355,7 @@ class Sticky extends Component {
         var enableTransforms = canEnableTransforms && this.props.enableTransforms
         if (enableTransforms && this.state.activated) {
             const { translateX } = this.props;
-            let xpos = translateX ? translateX + 'px' : 0;
+            let xpos = translateX && this.state.status === STATUS_FIXED ? translateX + 'px' : 0;
             style[TRANSFORM_PROP] = 'translate3d('+xpos+', '+pos+'px,0)';
         } else {
             style.top = pos + 'px';

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -45,7 +45,7 @@ class Sticky extends Component {
         this.bottomBoundaryTarget;
         this.topTarget;
         this.subscribers;
-        
+
         const { width=0, translateX=0 } = props;
 
         this.state = {


### PR DESCRIPTION
Enabling a user defined `width` and `translateX` in props makes `<Sticky />` friendlier to horizontal scrolls. 

If a `scroll` handler was added to the child component, the offsetX can be adjusted when Sticky is active.