### PR TITLE
Add project .babelrc to avoid using root configs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  breakConfig: true
+}


### PR DESCRIPTION
Babel will look for config files in parent directories unless you tell it not to. 

This package uses Babel 5 but might be used in projects that use Babel 6 and as such can contain configs what Babel 5 would consider invalid. 

In order to prevent build failures we define a config file for this repo and set it up to tell Babel to stop looking for other config files.
