### PR TITLE
style(prop-types): for react 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "react-addons-test-utils": "^0.14.2 || ^15.0.0",
     "react-dom": "^0.14.2 || ^15.0.0",
     "sinon": "^1.17.3",
-    "xunit-file": "~0.0.9"
+    "xunit-file": "~0.0.9",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.14.2 || ^15.0.0",

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -6,7 +6,8 @@
 
 'use strict';
 
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types'
 
 import {subscribe} from 'subscribe-ui-event';
 import classNames from 'classnames';


### PR DESCRIPTION
To avoid: Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types
package from npm instead.