### PR TITLE
Add ability to provide bottom boundary offset

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -87,9 +87,10 @@ class Sticky extends Component {
         return this.scrollTop + rect.bottom;
     }
 
-    getBottomBoundary (bottomBoundary) {
+    getBottomBoundary (bottomBoundary, bottomBoundaryOffset) {
         // a bottomBoundary can be provided to avoid reading from the props
         var boundary = bottomBoundary || this.props.bottomBoundary;
+        var boundaryOffset = bottomBoundaryOffset || this.props.bottomBoundaryOffset || 0;
 
         // TODO, bottomBoundary was an object, depricate it later.
         if (typeof boundary === 'object') {
@@ -102,7 +103,7 @@ class Sticky extends Component {
             }
             boundary = this.getTargetBottom(this.bottomBoundaryTarget);
         }
-        return boundary && boundary > 0 ? boundary : Infinity;
+        return boundary && (boundary + boundaryOffset) > 0 ? (boundary + boundaryOffset) : Infinity;
     }
 
     reset () {
@@ -149,7 +150,7 @@ class Sticky extends Component {
             height: height,
             x: outerRect.left,
             y: outerY,
-            bottomBoundary: this.getBottomBoundary(options.bottomBoundary),
+            bottomBoundary: this.getBottomBoundary(options.bottomBoundary, options.bottomBoundaryOffset),
             topBoundary: outerY
         });
     }
@@ -423,6 +424,7 @@ Sticky.propTypes = {
         PropTypes.string,
         PropTypes.number
     ]),
+    bottomBoundaryOffset: PropTypes.number,
     enableTransforms: PropTypes.bool,
     activeClass: PropTypes.string,
     releasedClass: PropTypes.string,

--- a/tests/unit/Sticky-test.js
+++ b/tests/unit/Sticky-test.js
@@ -428,4 +428,100 @@ describe('Sticky', function () {
         expect(parent.refs.sticky.props.enabled).to.eql(true);
         expect(parent.refs.sticky.state.activated).to.eql(true);
     });
+
+    it('should work as expected with original top 20px, 400px bottom boundary, and -20px bottom boundary offset (short Sticky)', function () {
+        STICKY_TOP = 20;
+        sticky = jsx.renderComponent(Sticky, {
+            bottomBoundary: 400,
+            bottomBoundaryOffset: -20
+        });
+        outer = ReactDOM.findDOMNode(sticky);
+        inner = outer.firstChild;
+
+        // regular case
+        expect(outer.className).to.contain('sticky-outer-wrapper');
+        expect(inner.className).to.contain('sticky-inner-wrapper');
+        // should always have translate3d
+        checkTransform3d(inner);
+
+        // Scroll down to 10px, and Sticky should stay
+        window.scrollTo(0, 10);
+        shouldBeReset(inner);
+        expect(outer.className).to.not.contain('active');
+        expect(outer.className).to.not.contain('released');
+
+        // Scroll down to 50px, and Sticky should fix
+        window.scrollTo(0, 50);
+        shouldBeFixedAt(inner, 0);
+        expect(outer.className).to.contain('active');
+        expect(outer.className).to.not.contain('released');
+
+        // Scroll down to 150px, and Sticky should release
+        window.scrollTo(0, 150);
+        shouldBeReleasedAt(inner, 60); // 20 + 300 + 60 = (400 + -20)
+        expect(outer.className).to.not.contain('active');
+        expect(outer.className).to.contain('released');
+    });
+
+    it('should not be sticky if bottom boundary + bottom boundary offset is shorter then its height (short Sticky)', function () {
+        sticky = jsx.renderComponent(Sticky, {
+            bottomBoundary: 400,
+            bottomBoundaryOffset: -101
+        });
+        outer = ReactDOM.findDOMNode(sticky);
+        inner = outer.firstChild;
+
+        // regular case
+        expect(outer.className).to.contain('sticky-outer-wrapper');
+        expect(inner.className).to.contain('sticky-inner-wrapper');
+        // should always have translate3d
+        checkTransform3d(inner);
+
+        // Scroll down to 10px, and Sticky should stay
+        window.scrollTo(0, 10);
+        shouldBeReset(inner);
+        expect(outer.className).to.not.contain('active');
+        expect(outer.className).to.not.contain('released');
+
+        // Micic status was not 0 (STATUS_ORIGINAL), scroll down to 20px, and Sticky should stay
+        sticky.state.status = 2; // STATUS_FIXED;
+        window.scrollTo(0, 20);
+        shouldBeReset(inner);
+        expect(outer.className).to.not.contain('active');
+        expect(outer.className).to.not.contain('released');
+    });
+
+    it('should work as expected with selector bottom boundary + bottom boundary offset (short Sticky)', function () {
+        sticky = jsx.renderComponent(Sticky, {
+            top: '#test',
+            bottomBoundary: '#test',
+            bottomBoundaryOffset: -20
+        });
+        outer = ReactDOM.findDOMNode(sticky);
+        inner = outer.firstChild;
+
+        // regular case
+        expect(outer.className).to.contain('sticky-outer-wrapper');
+        expect(inner.className).to.contain('sticky-inner-wrapper');
+        // should always have translate3d
+        checkTransform3d(inner);
+
+        // Scroll down to 10px, and Sticky should fix
+        window.scrollTo(0, 10);
+        shouldBeFixedAt(inner, 20);
+        expect(outer.className).to.contain('active');
+        expect(outer.className).to.not.contain('released');
+
+        // Scroll down to 50px, and Sticky should fix
+        window.scrollTo(0, 50);
+        shouldBeFixedAt(inner, 20);
+        expect(outer.className).to.contain('active');
+        expect(outer.className).to.not.contain('released');
+
+        // Scroll down to 150px, and Sticky should release
+        window.scrollTo(0, 150);
+        shouldBeReleasedAt(inner, 80); // 400 - 300 + (-20)
+        expect(outer.className).to.not.contain('active');
+        expect(outer.className).to.contain('released');
+    });
 });


### PR DESCRIPTION
For my use case, I have a table that contains subheaders. Each subheader is wrapped in Sticky and the next subheader is used as the bottom boundary. However, I actually need the current Sticky to release at the top of the bottomBoundary element. I figured the easiest way to do this was to provide ability to specify a bottomBoundaryOffset. Let me know if you guys will consider merging this in or if you need anything else from me.

Thanks!