### PR TITLE
Refactor legacy code - use PureComponent instead of shallowCompare

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-stickynode",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A performant and comprehensive React sticky",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "classnames": "^2.0.0",
     "prop-types": "^15.6.0",
-    "react-addons-shallow-compare": "^0.14.2 || ^15.0.0",
     "subscribe-ui-event": "^1.0.0"
   },
   "devDependencies": {

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -11,7 +11,6 @@ import PropTypes from 'prop-types'
 
 import {subscribe} from 'subscribe-ui-event';
 import classNames from 'classnames';
-import shallowCompare from 'react-addons-shallow-compare';
 
 // constants
 const STATUS_ORIGINAL = 0; // The default status, locating at the original position.
@@ -30,7 +29,7 @@ var scrollDelta = 0;
 var win;
 var winHeight = -1;
 
-class Sticky extends Component {
+class Sticky extends PureComponent {
     constructor (props, context) {
         super(props, context);
         this.handleResize = this.handleResize.bind(this);
@@ -326,7 +325,7 @@ class Sticky extends Component {
             winHeight = win.innerHeight || docEl.clientHeight;
             M = window.Modernizr;
             // No Sticky on lower-end browser when no Modernizr
-            if (M && M.prefixed) {
+            if (M) {
                 canEnableTransforms = M.csstransforms3d;
                 TRANSFORM_PROP = M.prefixed('transform');
             }
@@ -358,7 +357,7 @@ class Sticky extends Component {
     }
 
     shouldComponentUpdate (nextProps, nextState) {
-        return !this.props.shouldFreeze() && shallowCompare(this, nextProps, nextState);
+        return !this.props.shouldFreeze();
     }
 
     render () {

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import React, {Component} from 'react';
+import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types'
 
 import {subscribe} from 'subscribe-ui-event';

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -326,7 +326,7 @@ class Sticky extends Component {
             winHeight = win.innerHeight || docEl.clientHeight;
             M = window.Modernizr;
             // No Sticky on lower-end browser when no Modernizr
-            if (M) {
+            if (M && M.prefixed) {
                 canEnableTransforms = M.csstransforms3d;
                 TRANSFORM_PROP = M.prefixed('transform');
             }

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -325,7 +325,7 @@ class Sticky extends PureComponent {
             winHeight = win.innerHeight || docEl.clientHeight;
             M = window.Modernizr;
             // No Sticky on lower-end browser when no Modernizr
-            if (M) {
+            if (M && M.prefixed) {
                 canEnableTransforms = M.csstransforms3d;
                 TRANSFORM_PROP = M.prefixed('transform');
             }


### PR DESCRIPTION
Easy refactoring and remove dependency.

https://www.npmjs.com/package/react-addons-shallow-compare

"react-addons-shallow-compare
Note: This is a legacy React addon, and is no longer maintained.

We don't encourage using it in new code, but it exists for backwards compatibility.
The recommended migration path is to use React.PureComponent instead."