### PR TITLE
Update refs element usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-stickynode",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "A performant and comprehensive React sticky",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-stickynode",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A performant and comprehensive React sticky",
   "main": "index.js",
   "scripts": {

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -133,10 +133,8 @@ class Sticky extends Component {
     updateInitialDimension (options) {
         options = options || {}
 
-        var {outer, inner} = this.refs;
-
-        var outerRect = outer.getBoundingClientRect();
-        var innerRect = inner.getBoundingClientRect();
+        var outerRect = this.outerElement.getBoundingClientRect();
+        var innerRect = this.innerElement.getBoundingClientRect();
 
         var width = outerRect.width || outerRect.right - outerRect.left;
         var height = innerRect.height || innerRect.bottom - innerRect.top;;
@@ -383,8 +381,8 @@ class Sticky extends Component {
         })
 
         return (
-            <div ref='outer' className={outerClasses} style={outerStyle}>
-                <div ref='inner' className='sticky-inner-wrapper' style={innerStyle}>
+            <div ref={(outer) => { this.outerElement = outer; }} className={outerClasses} style={outerStyle}>
+                <div ref={(inner) => { this.innerElement = inner; }} className='sticky-inner-wrapper' style={innerStyle}>
                     {this.props.children}
                 </div>
             </div>

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -326,7 +326,7 @@ class Sticky extends Component {
             winHeight = win.innerHeight || docEl.clientHeight;
             M = window.Modernizr;
             // No Sticky on lower-end browser when no Modernizr
-            if (M) {
+            if (M && M.prefixed) {
                 canEnableTransforms = M.csstransforms3d;
                 TRANSFORM_PROP = M.prefixed('transform');
             }

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -326,7 +326,7 @@ class Sticky extends Component {
             winHeight = win.innerHeight || docEl.clientHeight;
             M = window.Modernizr;
             // No Sticky on lower-end browser when no Modernizr
-            if (M && M.prefixed) {
+            if (M) {
                 canEnableTransforms = M.csstransforms3d;
                 TRANSFORM_PROP = M.prefixed('transform');
             }


### PR DESCRIPTION
Update refs usage to new api and don't use string refs

https://reactjs.org/docs/refs-and-the-dom.html

"Legacy API: String Refs
If you worked with React before, you might be familiar with an older API where the ref attribute is a string, like "textInput", and the DOM node is accessed as this.refs.textInput. We advise against it because string refs have some issues, are considered legacy, and are likely to be removed in one of the future releases. If you’re currently using this.refs.textInput to access refs, we recommend the callback pattern instead."