### PR TITLE
Add Math.round to translate3d

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -351,7 +351,7 @@ class Sticky extends Component {
     translate (style, pos) {
         var enableTransforms = canEnableTransforms && this.props.enableTransforms
         if (enableTransforms && this.state.activated) {
-            style[TRANSFORM_PROP] = 'translate3d(0,' + pos + 'px,0)';
+            style[TRANSFORM_PROP] = 'translate3d(0,' + Math.round(pos) + 'px,0)';
         } else {
             style.top = pos + 'px';
         }


### PR DESCRIPTION
translate function can reseive non-integer pos and it causes font smoothing in Chrome (if bottomBoundary element has non-integer height for example). We can call Math.round on pos to prevent it.