### PR TITLE
Fix/unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: node_js
 node_js:
   - lts/*
 after_success:
-  - "npm run func"
+  - "npm run ci"
   - "cat artifacts/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,6 @@ module.exports = function (grunt) {
         tmp: 'tmp',
         unit: 'tests/unit',
         functional: 'tests/functional',
-        spec: 'tests/spec',
         coverage_dir: grunt.option('coverage_dir') || 'artifacts',
         test_results_dir: grunt.option('test_results_dir') || 'artifacts'
     };
@@ -313,8 +312,18 @@ module.exports = function (grunt) {
     // dist
     // 1. clean dist/
     // 2. compile jsx to js in dist/
-    grunt.registerTask('dist', ['clean:dist', 'babel:dist']);
-    grunt.registerTask('test', ['clean:dist', 'babel:dist', 'clean:tmp', 'babel:unit']);
+    grunt.registerTask('dist', [
+        'clean:dist',
+        'babel:dist'
+    ]);
+
+    grunt.registerTask('test', [
+        'clean:dist',
+        'babel:dist',
+        'clean:tmp',
+        'babel:unit',
+        'shell:mocha'
+    ]);
 
     // default
     grunt.registerTask('default', ['dist']);

--- a/README.md
+++ b/README.md
@@ -115,7 +115,12 @@ npm install react-stickynode
 
 **Unit Test**
 ```bash
-grunt unit
+npm run test
+```
+
+**Linting**
+```bash
+npm run lint
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "index.js",
   "scripts": {
     "build": "grunt dist",
-    "devtest": "grunt unit",
-    "func": "./tests/functional/saucelabs.sh",
+    "ci": "./tests/functional/saucelabs.sh",
     "lint": "eslint --cache --ext .js,.jsx . --fix",
     "prepublish": "grunt dist",
-    "test": "grunt cover"
+    "test": "grunt test",
+    "test:unit": "grunt unit",
+    "test:func": "grunt func"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #135

* Get unit tests passing (minimal changes)
* Update npm scripts to be a bit clearer about what they are doing & get `npm run test` to run tests
* Update readme to be clearer about running tests & linting + avoid the need for global grunt installation via the use of `npm run test`
* Update cover to be a specific npm ci script (to avoid confusion), and update travis.yml accordingly
* Note: it appears that functional tests are still failing and not run in existing scripts, but this does not fix those issues, only the unit tests.

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
