### PR TITLE
Unit Tests - ensure that updates gracefully handle enabled=False

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint --cache --ext .js,.jsx . --fix",
     "prepublish": "npm run build",
     "test": "jest --coverage tests/unit",
-    "test:func": "grunt func"
+    "test:func": "grunt func",
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/tests/unit/Sticky.test.js
+++ b/tests/unit/Sticky.test.js
@@ -465,19 +465,42 @@ describe('Sticky', () => {
                     this.sticky = element;
                 };
 
-                this.state = { enabled: true }; 
+                this.state = { boundary: '', enabled: true, name: 'JOE' }; 
             }
 
             render() {
-                return <Sticky ref="sticky" enabled={this.state.enabled} />
+                return (
+                    <Sticky
+                        ref="sticky"
+                        bottomBoundary={`#boundary{this.state.boundary}`}
+                        enabled={this.state.enabled}
+                    >
+                        {this.state.name}
+                        {this.state.enabled && <div id="boundary"/>}
+                    </Sticky>
+                )
             }
         }
 
         var parent = ReactTestUtils.renderIntoDocument(React.createElement(TestComponent, {}));
+
         // toggle the enabled prop off
         parent.setState({enabled: false});
         expect(parent.refs.sticky.props.enabled).toEqual(false);
         expect(parent.refs.sticky.state.activated).toEqual(false);
+        expect(parent.refs.sticky.props.children).toContain('JOE');
+
+        // should not error while not enabled & other props changed
+        parent.setState({name: 'JENKINS'});
+        expect(parent.refs.sticky.props.enabled).toEqual(false);
+        expect(parent.refs.sticky.props.children).toContain('JENKINS');
+
+        // should not error while not enabled & boundary changes
+        parent.setState({boundary: '-not-present'});
+        expect(parent.refs.sticky.props.enabled).toEqual(false);
+        expect(parent.refs.sticky.props.children).toContain('JENKINS');
+        parent.setState({boundary: ''});
+
         // toggle the enabled prop on
         parent.setState({enabled: true});
         expect(parent.refs.sticky.props.enabled).toEqual(true);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---
Adds unit tests to ensure that a regression like #131 should not happen in the future.

Note: The problem on #131 has been resolved in the refactor to `componentDidUpdate` and some more defensive checks in the `getBottomBoundary` method.

Nonetheless, this should help ensure that a similar problem does not happen, by validating that updates to the component, while disabled, do not trigger additional internal updates that are not necessary.

Also, added a jest watch script.