### PR TITLE
Fixes debouncing calls updateInitialDimension after element detroyed

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -132,6 +132,10 @@ class Sticky extends Component {
     updateInitialDimension (options) {
         options = options || {}
 
+        if (!this.outerElement || !this.innerElement) {
+            return;
+        }
+
         var outerRect = this.outerElement.getBoundingClientRect();
         var innerRect = this.innerElement.getBoundingClientRect();
 


### PR DESCRIPTION
Fixes issue were because of debouncing updateInitialDimension is triggered after outerElement is already destroyed.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
