### PR TITLE
added className to component props and updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ import Sticky from 'react-stickynode';
 | `enableTransforms` | Boolean | Enable the use of CSS3 transforms (true by default). |
 | `activeClass` | String | Class name to be applied to the element when the sticky state is active (`active` by default). |
 | `innerClass` | String | Class name to be applied to the inner element (`''` by default). |
+| `className` | String | Class name to be applied to the element independent of the sticky state. |
 | `releasedClass` | String | Class name to be applied to the element when the sticky state is released (`released` by default). |
 | `onStateChange` | Function | Callback for when the sticky state changes. See below. |
 | `shouldFreeze` | Function | Callback to indicate when the sticky plugin should freeze position and ignore scroll/resize events. See below. |

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -434,6 +434,7 @@ Sticky.propTypes = {
     activeClass: PropTypes.string,
     releasedClass: PropTypes.string,
     innerClass: PropTypes.string,
+    className: PropTypes.string,
     onStateChange: PropTypes.func,
     shouldFreeze: PropTypes.func,
     innerZ: PropTypes.oneOfType([


### PR DESCRIPTION
Updated the props and documentation with className prop since it is beeing used by the component and therefore can be passed.

In order to can update @types/react-stickynode this should be done before :-)

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
