### PR TITLE
Enhance entrypoint in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/Sticky');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-stickynode",
   "version": "3.0.5",
   "description": "A performant and comprehensive React sticky component",
-  "main": "index.js",
+  "main": "dist/Sticky.js",
   "scripts": {
     "build": "babel src --out-dir dist",
     "ci": "./tests/functional/saucelabs.sh",


### PR DESCRIPTION
This removes the obsolete `index.js` file and directly sets the `main` field to `dist/Sticky.js` instead.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
