### PR TITLE
Add innerActiveClass prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ import Sticky from 'react-stickynode';
 | `enableTransforms` | Boolean | Enable the use of CSS3 transforms (true by default). |
 | `activeClass` | String | Class name to be applied to the element when the sticky state is active (`active` by default). |
 | `innerClass` | String | Class name to be applied to the inner element (`''` by default). |
+| `innerActiveClass` | String | Class name to be applied to the inner element when the sticky state is active (`''` by default). |
 | `className` | String | Class name to be applied to the element independent of the sticky state. |
 | `releasedClass` | String | Class name to be applied to the element when the sticky state is released (`released` by default). |
 | `onStateChange` | Function | Callback for when the sticky state changes. See below. |

--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -386,11 +386,15 @@ class Sticky extends Component {
             [this.props.releasedClass]: this.state.status === STATUS_RELEASED
         })
 
+        var innerClasses = classNames('sticky-inner-wrapper', this.props.innerClass, {
+            [this.props.innerActiveClass]: this.state.status === STATUS_FIXED
+        })
+
         var children = this.props.children;
 
         return (
             <div ref={(outer) => { this.outerElement = outer; }} className={outerClasses} style={outerStyle}>
-                <div ref={(inner) => { this.innerElement = inner; }} className={['sticky-inner-wrapper', this.props.innerClass].join(' ')} style={innerStyle}>
+                <div ref={(inner) => { this.innerElement = inner; }} className={innerClasses} style={innerStyle}>
                     {typeof children === 'function' ? children({ status: this.state.status }) : children}
                 </div>
             </div>
@@ -410,6 +414,7 @@ Sticky.defaultProps = {
     releasedClass: 'released',
     onStateChange: null,
     innerClass: '',
+    innerActiveClass: '',
 };
 
 /**
@@ -434,6 +439,7 @@ Sticky.propTypes = {
     activeClass: PropTypes.string,
     releasedClass: PropTypes.string,
     innerClass: PropTypes.string,
+    innerActiveClass: PropTypes.string,
     className: PropTypes.string,
     onStateChange: PropTypes.func,
     shouldFreeze: PropTypes.func,

--- a/tests/unit/Sticky.test.js
+++ b/tests/unit/Sticky.test.js
@@ -506,4 +506,44 @@ describe('Sticky', () => {
         expect(parent.refs.sticky.props.enabled).toEqual(true);
         expect(parent.refs.sticky.state.activated).toEqual(true);
     });
+
+    test('should apply custom class props', () => {
+        const { container } = render(
+            <Sticky
+                bottomBoundary={400}
+                activeClass='custom-active'
+                innerActiveClass='custom-inner-active'
+                innerClass='custom-inner'
+                className='custom'
+                releasedClass='custom-released'
+            />
+        );
+
+        outer = container.querySelector(`.${STICKY_CLASS_OUTER}`);
+        inner = container.querySelector(`.${STICKY_CLASS_INNER}`);
+        
+        expect(outer.className).toContain('custom');
+        expect(inner.className).toContain('custom-inner');
+
+        // Scroll down to 10px, and Sticky should fix
+        window.scrollTo(0, 10);
+        shouldBeFixedAt(inner, 0);
+        expect(outer.className).toContain('custom-active');
+        expect(outer.className).not.toContain('custom-released');
+        expect(inner.className).toContain('custom-inner-active');
+        
+        // Scroll up to 0px, and Sticky should reset
+        window.scrollTo(0, 0);
+        shouldBeReset(inner);
+        expect(outer.className).not.toContain('custom-active');
+        expect(outer.className).not.toContain('custom-released');
+        expect(inner.className).not.toContain('custom-inner-active');
+
+        // Scroll down to 150px, and Sticky should release
+        window.scrollTo(0, 150);
+        shouldBeReleasedAt(inner, 100);
+        expect(outer.className).not.toContain('custom-active');
+        expect(outer.className).toContain('custom-released');
+        expect(inner.className).not.toContain('custom-inner-active');
+    });
 });


### PR DESCRIPTION
As requested in https://github.com/yahoo/react-stickynode/issues/275, new prop `innerActiveClass` can now be specified to set a class on the inner element when the sticky state is active.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
