### PR TITLE
Enable resize events for when the bottom boundary target is an element

### DIFF
--- a/src/Sticky.jsx
+++ b/src/Sticky.jsx
@@ -28,6 +28,7 @@ let M;
 let scrollDelta = 0;
 let win;
 let winHeight = -1;
+let resizeObserver;
 
 class Sticky extends Component {
     constructor(props, context) {
@@ -97,6 +98,15 @@ class Sticky extends Component {
         if (typeof boundary === 'string') {
             if (!this.bottomBoundaryTarget) {
                 this.bottomBoundaryTarget = doc.querySelector(boundary);
+            }
+            if (this.bottomBoundaryTarget) {
+                if (!resizeObserver) {
+                    resizeObserver = new ResizeObserver(() => {
+                        this.updateInitialDimension();
+                        this.update();
+                    });
+                }
+                resizeObserver.observe(this.bottomBoundaryTarget);
             }
             boundary = this.getTargetBottom(this.bottomBoundaryTarget);
         }


### PR DESCRIPTION
When a bottom boundary is set a document element, when the bottom boundary changes size the sticky component does not follow it.

This PR adds just that fix with the Observer API which accepted in all major browsers (https://caniuse.com/resizeobserver)

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
